### PR TITLE
Hidden rows: works for watching selector rows

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,3 @@ DEPENDENCIES
   motion-redgreen (~> 0.1)
   motion-stump (~> 0.3)
   rake
-
-BUNDLED WITH
-   1.10.6

--- a/app/screens/test_form_screen.rb
+++ b/app/screens/test_form_screen.rb
@@ -231,7 +231,14 @@ class TestFormScreen < PM::XLFormScreen
             name: :hide_me,
             type: :info,
             hidden: ':show_me not contains "hello"'
-          }
+          },
+          {
+            title: 'Value 1 ?',
+            name: :show_me_selector,
+            type: :text,
+            hidden: { name: :options, is: :equal, value: 'value_1', options: true },
+            value: 'is selected !'
+          },
         ]
       },
       {

--- a/lib/ProMotion/XLForm/xl_form_helper.rb
+++ b/lib/ProMotion/XLForm/xl_form_helper.rb
@@ -37,6 +37,8 @@ module ProMotion
         elsif tag.start_with?(':')
           tag[0] = ''
         end
+        tag += ".value.valueData" if predicate.is_a?(Hash) && predicate[:options]
+
         value = case value
                   when nil
                     'nil'

--- a/spec/test_xlform_screen_spec.rb
+++ b/spec/test_xlform_screen_spec.rb
@@ -128,6 +128,21 @@ describe 'ProMotion::XLFormScreen' do
     hide_me.isHidden.should == false
   end
 
+  it "should play hide and seek with a selector" do
+    predicate = "$options.value.valueData == 'value_1'".formPredicate
+    show_me_selector = @form_screen.cell_with_tag(:show_me_selector)
+    show_me_selector.hidden.should == predicate
+    show_me_selector.isHidden.should == true
+
+    selector = @form_screen.cell_with_tag('options')
+    selector.value = 'value_2'
+    @form_screen.reload(selector)
+
+    @form_screen.reload(show_me_selector)
+
+    show_me_selector.isHidden.should == false
+  end
+
   it "should get a color" do
     color_cell = @form_screen.cell_with_tag(:color)
     color_cell.value.should == UIColor.blueColor


### PR DESCRIPTION
I'd prefer to not have to pass an extra option in the hidden hash, but it's be a lot messier for a cell to be aware of the cell it's watching when it's built.

Fix reference: https://github.com/xmartlabs/XLForm/issues/377
