### PR TITLE
Fix :insert_mode => :button bug

### DIFF
--- a/app/screens/test_form_screen.rb
+++ b/app/screens/test_form_screen.rb
@@ -175,6 +175,19 @@ class TestFormScreen < PM::XLFormScreen
         ]
       },
       {
+        title: 'Multi-value with XLFormSectionInsertModeButton',
+        name: 'multi',
+        options: [:insert, :delete, :reorder],
+        insert_mode: :button,
+        cells: [
+          {
+            title: 'Some text',
+            name: :some_text,
+            type: :text
+          }
+        ]
+      },
+      {
         title: 'Subcells',
         name: :sub_cells,
         options: [:insert, :delete, :reorder],

--- a/lib/ProMotion/XLForm/xl_form_patch.rb
+++ b/lib/ProMotion/XLForm/xl_form_patch.rb
@@ -60,17 +60,17 @@ class XLFormRowDescriptor
       end
 
       if self.cell && self.cell.respond_to?(:setup)
-        self.cell.setup(cell_data, form_controller) 
+        self.cell.setup(cell_data, form_controller)
       end
       self.configureCellAtCreationTime
     end
-    
-    self.cell 
+
+    self.cell
   end
 end
 
 class XLFormSectionDescriptor
-  attr_accessor :section_data, :options
+  attr_accessor :section_data
 
   def self.section(section_data)
     title = section_data[:title]
@@ -81,21 +81,26 @@ class XLFormSectionDescriptor
 
     section = XLFormSectionDescriptor.formSectionWithTitle(title, sectionOptions: options, sectionInsertMode: insert_mode)
     section.section_data = section_data
-    section.options = options
+
     section
   end
 
   def options=(value)
-    @options = self.class.parse_section_options(value)
+    @section_options = self.class.parse_section_options(value)
   end
 
-  def options
-    @options
-  end
+  # Since `sectionOptions` is a property on the Objective-C class and not a
+  # Ruby method we can't use `super` to fallback when overriding the method.
+  # To achieve the same thing we create an alias and use that instead.
+  alias :originalSectionOptions :sectionOptions
 
+  # This property/method is used in the Objective-C initializer and is called
+  # before we ever have a chance to set @section_options so we need to be able
+  # to fallback to the original.
   def sectionOptions
-    options
+    @section_options || originalSectionOptions
   end
+  alias_method :options, :sectionOptions
 
   def self.parse_section_options(options)
     return section_options(:none) if options.nil?

--- a/lib/ProMotion/XLForm/xl_form_screen.rb
+++ b/lib/ProMotion/XLForm/xl_form_screen.rb
@@ -188,7 +188,7 @@ module ProMotion
     def enabled?
       !self.form.isDisabled
     end
-    
+
     # dismiss keyboard
     def dismiss_keyboard
       self.view.endEditing true
@@ -283,7 +283,7 @@ module ProMotion
       cell_class = cell.class
       if cell_class.respond_to?(:formDescriptorCellHeightForRowDescriptor)
         return cell_class.formDescriptorCellHeightForRowDescriptor(row)
-      elsif row.respond_to?(:cell_data) && row.cell_data[:height]
+      elsif row.respond_to?(:cell_data) && row.cell_data && row.cell_data[:height]
         return row.cell_data[:height]
       end
       self.tableView.rowHeight

--- a/spec/test_xlform_screen_spec.rb
+++ b/spec/test_xlform_screen_spec.rb
@@ -17,8 +17,8 @@ describe 'ProMotion::XLFormScreen' do
     view("Some help text").should.not.be.nil
   end
 
-  it "contains 8 sections" do
-    views(UITableView).first.numberOfSections.should == 8
+  it "contains 9 sections" do
+    views(UITableView).first.numberOfSections.should == 9
   end
 
   it "contains 1 section with 8 fields" do


### PR DESCRIPTION
This is a fix for #23 (cc @bmichotte)

Setting `:insert_mode` to `:button` was causing a crash. Here was the issue:

This gem was monkey patching `sectionOptions` to return the Ruby object's `options` instance variable. However, sectionOptions was being called in the Obj-C section initializer (XLFormSectionDescriptor.formSectionWithTitle) BEFORE we were able to set `options` on the ruby object.

Why was this only an issue with the :button option? Well in that Obj-C initializer there's a call to `canInsertUsingButton`:
- https://github.com/xmartlabs/XLForm/blob/master/XLForm/XL/Descriptors/XLFormSectionDescriptor.m#L85
- https://github.com/xmartlabs/XLForm/blob/master/XLForm/XL/Descriptors/XLFormSectionDescriptor.m#L322-L325

That method is a two-part conditional. The first is `is the insert mode set to button?` and the second is `do the section options indicate that I can insert?`. The second part was where the crash was occurring but it was never getting there because the first part was evaluating to false.

The changes here:
- Stop monkey-patching `sectionOptions`. I couldn't see any reason this gem needed to be doing that.
- Took out the setter/getter for section#options. The custom setter was unnecessary since we're already parsing the options in the only spot where we're calling that setter. And then if we don't need a custom setter, both the setter/getter are redundant because `options` is an `attr_accessor`.
