### PR TITLE
Add ability to add custom title for 'XLFormSectionInsertModeButton'

### DIFF
--- a/lib/ProMotion/XLForm/xl_form_section_builder.rb
+++ b/lib/ProMotion/XLForm/xl_form_section_builder.rb
@@ -21,6 +21,10 @@ module ProMotion
 
       section.footerTitle = section_data[:footer] if section_data[:footer]
 
+      if section.multivaluedAddButton
+        section.multivaluedAddButton.title = section_data[:multi_add_title] if section_data[:multi_add_title]
+      end
+
       add_proc tag, :on_add, section_data[:on_add] if section_data[:on_add]
       add_proc tag, :on_remove, section_data[:on_remove] if section_data[:on_remove]
 


### PR DESCRIPTION
Adds the ability to add a custom title to the standard `Add Item` button on section `insert_mode: :button`

https://github.com/xmartlabs/XLForm/blob/a4fc47d5b0a7fe32dfd3e8df524b59d2bfbc5f59/Examples/Swift/SwiftExample/MultiValuedSections/MultivaluedFormViewController.swift#L49
