### PR TITLE
Fix cell builder to use stepValue for step_counter

### DIFF
--- a/lib/ProMotion/XLForm/xl_form_cell_builder.rb
+++ b/lib/ProMotion/XLForm/xl_form_cell_builder.rb
@@ -44,7 +44,7 @@ module ProMotion
         cell.cellConfigAtConfigure.setObject(true, forKey: "stepControl.wraps")
         cell.cellConfigAtConfigure.setObject(min, forKey: "stepControl.minimumValue") if min
         cell.cellConfigAtConfigure.setObject(max, forKey: "stepControl.maximumValue") if max
-        cell.cellConfigAtConfigure.setObject(step, forKey: "stepControl.maximumValue") if step
+        cell.cellConfigAtConfigure.setObject(step, forKey: "stepControl.stepValue") if step
       end
 
       # slider


### PR DESCRIPTION
This fixes a typo for step_counter type option "steps"
