### PR TITLE
Add zip_code as a form element type

### DIFF
--- a/lib/ProMotion/XLForm/xl_form.rb
+++ b/lib/ProMotion/XLForm/xl_form.rb
@@ -60,6 +60,7 @@ module ProMotion
         integer: XLFormRowDescriptorTypeInteger,
         decimal: XLFormRowDescriptorTypeDecimal,
         textview: XLFormRowDescriptorTypeTextView,
+        zip_code: XLFormRowDescriptorTypeZipCode,
         selector_push: XLFormRowDescriptorTypeSelectorPush,
         selector_popover: XLFormRowDescriptorTypeSelectorPopover,
         selector_action_sheet: XLFormRowDescriptorTypeSelectorActionSheet,


### PR DESCRIPTION
The zip_code option for a form type was not available, so I have now added it. This will allow a field to be defaulted to an uppercase keyboard.
