### PR TITLE
set XLForm to 3.1.1 for stability

### DIFF
--- a/lib/ProMotion-XLForm.rb
+++ b/lib/ProMotion-XLForm.rb
@@ -26,7 +26,7 @@ Motion::Project::App.setup do |app|
   app.files << File.join(lib_dir_path, "ProMotion/XLForm/ui_alert_controller.rb")
 
   app.pods do
-    pod 'XLForm', git: 'https://github.com/xmartlabs/XLForm.git'
+    pod 'XLForm', '3.1.1'
     pod 'RSColorPicker'
   end
 end


### PR DESCRIPTION
This fixes the issue that causes the following error on submit. 

```
Terminating app due to uncaught exception 'TypeError', reason: 'xl_form_screen.rb:97:in `valid?': can't convert Class into String
```

Related to https://github.com/bmichotte/ProMotion-XLForm/issues/50

It also keeps a fixed version of XLForm that will stop breaking the gem when they update the cocoapod.
